### PR TITLE
fix: support Stencil >=4.43 lazy CSS arrow function emission

### DIFF
--- a/src/custom-suffix-output-target.ts
+++ b/src/custom-suffix-output-target.ts
@@ -279,7 +279,11 @@ export async function processCSS(
   code: string,
   tagNames: string[],
 ): Promise<string> {
-  const cssRegex = /const\s+(\w+Css)\s*=\s*"((?:\\.|[^"\\])*)"/g;
+  // Matches both old Stencil (<4.43) and new Stencil (>=4.43) CSS emission:
+  //   Old: const fooCSS = "...";
+  //   New: const fooCSS = () => `...`;
+  const cssRegex =
+    /const\s+(\w+Css)\s*=\s*(?:(\(\)\s*=>\s*)`((?:\\.|[^`\\])*)`|"((?:\\.|[^"\\])*)")/g;
 
   let match: RegExpExecArray | null = cssRegex.exec(code);
 
@@ -291,11 +295,10 @@ export async function processCSS(
   };
 
   while (match !== null) {
-    const [fullMatch, varName, cssContent] = match as unknown as [
-      string,
-      string,
-      string,
-    ];
+    const fullMatch = match[0];
+    const varName = match[1];
+    const isLazy = match[2] !== undefined;
+    const cssContent = (match[3] ?? match[4]) as string;
     const result = await postcss([
       (root: postcss.Root) => {
         root.walkRules((rule) => {
@@ -329,7 +332,9 @@ export async function processCSS(
       },
     ]).process(cssContent, { parser: postcssSafeParser, from: undefined });
 
-    const updatedInitializer = `\`${result.css}\``;
+    const updatedInitializer = isLazy
+      ? `() => \`${result.css}\``
+      : `\`${result.css}\``;
     code = code.replace(fullMatch, `const ${varName} = ${updatedInitializer}`);
     match = cssRegex.exec(code);
   }

--- a/src/test/custom-suffix-output-target.spec.ts
+++ b/src/test/custom-suffix-output-target.spec.ts
@@ -31,6 +31,27 @@ describe('customSuffixOutputTarget', () => {
     expect(patchedContent).toBe(testData.expectedOutput);
   });
 
+  it('should patch CSS selectors when Stencil emits lazy () => `...` CSS initializers', async () => {
+    const lazyCssInput = testData.input.replace(
+      /const myComponentCss = "((?:\\.|[^"\\])*)";/,
+      (_, css) => `const myComponentCss = () => \`${css}\`;`,
+    );
+
+    setup.fileSystem[setup.fullPath] = lazyCssInput;
+
+    const outputTarget = target();
+    await outputTarget.generator(...setup.generatorParams);
+
+    const patchedContent = await setup.compiler.fs.readFile(setup.fullPath);
+
+    // CSS should be patched with suffix AND preserve the arrow function wrapper
+    expect(patchedContent).toContain(
+      'const myComponentCss = () => `my-button${suffix}{background-color:#007bff}my-checkbox${suffix}{border:1px solid #ccc}component{padding:10px}#component{display:block}.component{color:#333}::slotted(my-button${suffix}){font-weight:bold;}`',
+    );
+    // Verify it's NOT a bare template literal (no arrow function lost)
+    expect(patchedContent).not.toContain('const myComponentCss = `');
+  });
+
   it('should skip processing if tagNameTransform is not enabled', async () => {
     if (setup.config.extras) {
       setup.config.extras.tagNameTransform = false;


### PR DESCRIPTION
## Problem

Stencil 4.43 changed how it emits CSS variables in `dist-custom-elements` output:

```js
// Before (Stencil <4.43):
const myComponentCss = "my-button{...}";

// After (Stencil >=4.43):
const myComponentCss = () => \`my-button{...}\`;
```

The `processCSS` regex only matched the double-quoted string form, so CSS selectors were never patched on Stencil >=4.43.

## Fix

Updated the regex to match both forms:
- Old: `const fooCSS = "..."` (double-quoted string)
- New: `const fooCSS = () => \`...\`` (arrow function returning template literal)

When the arrow function form is detected, the patched output preserves the `() => \`...\`` wrapper.

Fully backward compatible — the old double-quoted form still works.

## Tests

Added a new test case verifying lazy CSS form is correctly patched with suffix interpolations while preserving the arrow function wrapper.