### PR TITLE
ci: use npm trusted publishing with OIDC for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -35,6 +38,4 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public


### PR DESCRIPTION
Replace NPM_TOKEN with OIDC trusted publishing for production releases.
- Added \`permissions: id-token: write\` to publish job
- Removed \`NODE_AUTH_TOKEN\` env (OIDC replaces it)
- Provenance attestations generated automatically
- Prereleases (\`create-prerelease.yml\`) still use \`NPM_TOKEN\`
**Prerequisite:** Trusted publisher must be configured on npmjs.com with workflow filename \`release-please.yml\`.