### PR TITLE
fix: skip components whose files cannot be read

### DIFF
--- a/src/custom-suffix-output-target.ts
+++ b/src/custom-suffix-output-target.ts
@@ -44,14 +44,19 @@ const targetObject = {
       let filePath = `${outputDir}/${cmp.tagName}2.js`;
       let originalContent = await compilerCtx.fs
         .readFile(filePath)
-        .catch(() => '');
+        .catch(() => undefined);
 
       if (originalContent === undefined) {
         filePath = `${outputDir}/${cmp.tagName}.js`;
         originalContent = await compilerCtx.fs
           .readFile(filePath)
-          .catch(() => '');
+          .catch(() => undefined);
       }
+
+      if (originalContent === undefined) {
+        continue;
+      }
+
       const transformedContent = await applyTransformers(
         filePath,
         originalContent,


### PR DESCRIPTION
## Problem

In dev mode, Stencil's `compilerCtx.fs.readFile()` can resolve with `undefined` instead of rejecting when a file doesn't exist. The previous `.catch(() => '')` only handled rejections, so `undefined` content was passed to `ts.createSourceFile()`, crashing with:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at createSourceFile2 (.../typescript/lib/typescript.js:33521:52)
```

This only manifests with TypeScript 5.9+ and `stencil build --dev`.

## Fix

- Normalize both `.catch()` handlers to return `undefined` instead of `''`
- Add an early `continue` when neither `<tag>2.js` nor `<tag>.js` can be read
- This skips components whose output files aren't available yet (e.g. incremental dev builds), rather than attempting to transform empty/undefined content

## Notes

- The previous `.catch(() => '')` also made the existing `=== undefined` check on the first read unreachable for rejection cases, since caught rejections returned `''`. Normalizing to `undefined` makes the fallback logic consistent.